### PR TITLE
IronPython support: catch and ignore 'readline' ImportError

### DIFF
--- a/DebugLibrary.py
+++ b/DebugLibrary.py
@@ -40,7 +40,11 @@ from robot.libraries.BuiltIn import BuiltIn
 import cmd
 import os
 import re
-import readline
+try:
+    import readline
+except ImportError:
+    # this will fail on IronPython
+    pass
 import sys
 
 __version__ = '0.3'


### PR DESCRIPTION
IronPython doesn't have 'readline' module. By ignoring the exception this library works.

The easiest way to install (on IronPython) seems to be to just copy DebugLibrary.py to somewhere in IRONPYTHONPATH.