### PR TITLE
Support assigning variables

### DIFF
--- a/DebugLibrary.py
+++ b/DebugLibrary.py
@@ -39,6 +39,7 @@ from __future__ import print_function
 from robot.errors import HandlerExecutionFailed
 from robot.libraries.BuiltIn import BuiltIn
 from robot.api import logger
+from robot.variables import is_var
 import cmd
 import os
 import re
@@ -133,9 +134,16 @@ class DebugCmd(BaseCmd):
         try:
             u_command = command.decode("utf-8")
             keyword = KEYWORD_SEP.split(u_command)
-            result = self.rf_bi.run_keyword(*keyword)
-            if result:
-                print('< ', repr(result))
+            variable_name = keyword[0].rstrip('= ')
+            
+            if is_var(variable_name):
+                variable_value = self.rf_bi.run_keyword(*keyword[1:])
+                self.rf_bi._variables.__setitem__(variable_name, variable_value)
+                print('< ', variable_name, '=', repr(variable_value))
+            else:
+                result = self.rf_bi.run_keyword(*keyword)
+                if result:
+                    print('< ', repr(result))
         except HandlerExecutionFailed as exc:
             print('< keyword: %s' % command)
             print('! %s' % exc.full_message)


### PR DESCRIPTION
Adds support for assigning variables, fixes #17 (and #18).

The implementation is somewhat ugly because the assignment is done by calling private a property and function. Tested with robotframework 3.0.

Assigning multiple variables is not implemented, but I'm sure it would be easy if someone needs it.

## Test cases

### Issue #18

    > ${labe_id}=  Set Variable  SOME TEXT
    <  ${labe_id} = u'SOME TEXT'
    > Log to console  ${labe_id}
    SOME TEXT

### Current time

    > ${secs} =  Get Time  epoch
    <  ${secs} = 1474565521
    > Log to console  ${secs}
    1474565521

### Examples from user guide
http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-values-from-keywords

    > @{list} =  Create List    first    second    third
    <  @{list} = [u'first', u'second', u'third']
    > Log to console  ${list}
    [u'first', u'second', u'third']

    > &{dict} =  Create Dictionary    first=1    second=${2}    ${3}=third
    <  &{dict} = {u'second': 2, 3: u'third', u'first': u'1'}
    > Log to console  ${dict.first}
    1
