### PR TITLE
Correct a frequently misspelled word

### DIFF
--- a/DebugLibrary.py
+++ b/DebugLibrary.py
@@ -307,7 +307,7 @@ class PtkCmd(BaseCmd):
     get_prompt_tokens = None
     prompt_style = None
     intro = '''\
-Only accepted plain text format keyword seperated with two or more spaces.
+Only accepted plain text format keyword separated with two or more spaces.
 Type "help" for more information.\
 '''
 
@@ -575,7 +575,7 @@ class DebugLibrary(object):
     def debug(self):
         """Open a interactive shell, run any RobotFramework keywords.
 
-        Keywords seperated by two space or one tab, and Ctrl-D to exit.
+        Keywords separated by two space or one tab, and Ctrl-D to exit.
         """
 
         # re-wire stdout so that we can use the cmd module and have readline
@@ -657,7 +657,7 @@ def shell():
             test_file.close()
             # pybot will raise PermissionError on Windows NT or later
             # if NamedTemporaryFile called with `delete=True`,
-            # deleting test file seperated will be OK.
+            # deleting test file separated will be OK.
             if os.path.exists(test_file.name):
                 os.unlink(test_file.name)
 


### PR DESCRIPTION
People frequently misspell **separate**. This PR makes the correction to three instances of the word **seperated**.