### PR TITLE
added support for command d(ocs)

### DIFF
--- a/DebugLibrary.py
+++ b/DebugLibrary.py
@@ -574,7 +574,7 @@ use the TAB keyboard key to autocomplete keywords.\
         """
 
         for lib in get_libs():
-            for keyword in get_lib_keywords(lib, True):
+            for keyword in get_lib_keywords(lib, long_format=True):
                 if keyword['name'].lower() == kw_name.lower():
                     print(keyword['doc'])
                     return

--- a/DebugLibrary.py
+++ b/DebugLibrary.py
@@ -141,12 +141,15 @@ class ImportedLibraryDocBuilder(LibraryDocBuilder):
 
 
 @memoize
-def get_lib_keywords(library):
+def get_lib_keywords(library, long_format=False):
     """Get keywords of imported library"""
     lib = ImportedLibraryDocBuilder().build(library)
     keywords = []
     for keyword in lib.keywords:
-        doc = keyword.doc.split('\n')[0]
+        if long_format:
+            doc = keyword.doc
+        else:
+            doc = keyword.doc.split('\n')[0]
         keywords.append({'name': keyword.name,
                          'lib': library.name,
                          'doc': doc})
@@ -564,6 +567,20 @@ use the TAB keyboard key to autocomplete keywords.\
 
     complete_k = complete_keywords
 
+    def do_docs(self, kw_name):
+        """Get keyword documentation for individual keywords
+
+         d(ocs) [<keyword_name>]
+        """
+
+        for lib in get_libs():
+            for keyword in get_lib_keywords(lib, True):
+                if keyword['name'].lower() == kw_name.lower():
+                    print(keyword['doc'])
+                    return
+        print("could not find documentation for keyword {}".format(kw_name))
+
+    do_d = do_docs
 
 class DebugLibrary(object):
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Or you can run it standalone as a ``RobotFramework`` shell::
 
     Documented commands (type help <topic>):
     ========================================
-    EOF  exit  help  k  keywords  l  libs  pdb  s  selenium
+    EOF  d  docs  exit  help  k  keywords  l  libs  pdb  s  selenium
 
     > log  hello
     > get time


### PR DESCRIPTION
Added support for getting all (long format) keyword documentation for individual imported keyword.

Adds this docs (or d) option to list of commands:

Documented commands (type help <topic>):
========================================
EOF  *d  docs*  exit  help  k  keywords  l  libs  pdb  s  selenium

...and that command displays full documentation for givenkeyword. For example:

> docs  Log to Console´

> Logs the given message to the console.
> 
> By default uses the standard output stream. Using the standard error
> stream is possibly by giving the ``stream`` argument value ``STDERR``
> (case-insensitive).
> 
> By default appends a newline to the logged message. This can be
> disabled by giving the ``no_newline`` argument a true value (see
> `Boolean arguments`).
> 
> Examples:
> | Log To Console | Hello, console!             |                 |
> | Log To Console | Hello, stderr!              | STDERR          |
> | Log To Console | Message starts here and is  | no_newline=true |
> | Log To Console | continued without newline.  |                 |
> 
> This keyword does not log the message to the normal log file. Use
> `Log` keyword, possibly with argument ``console``, if that is desired.

Feel free to modify/edit, but I've been missing getting longer keyword documentation for keywords as they often contain examples and such.