### PR TITLE
Minor improvements to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,11 @@ import re
 from setuptools import setup
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(ROOT, 'README.rst')).read()
-
-install_requires = ['prompt-toolkit < 3']  # 3.0 is not compatible with py3.5
-install_requires.append('robotframework >= 3.0')
 
 
 def read(*names, **kwargs):
     with io.open(
-        os.path.join(os.path.dirname(__file__), *names),
+        os.path.join(ROOT, *names),
         encoding=kwargs.get("encoding", "utf8")
     ) as fp:
         return fp.read()
@@ -34,7 +30,7 @@ setup(
     name='robotframework-debuglibrary',
     version=find_version('DebugLibrary/version.py'),
     description='RobotFramework debug library and an interactive shell',
-    long_description=README,
+    long_description=read('README.rst'),
     author='Xie Yanbo',
     author_email='xieyanbo@gmail.com',
     license='New BSD',
@@ -48,19 +44,25 @@ setup(
     zip_safe=False,
     url='https://github.com/xyb/robotframework-debuglibrary/',
     keywords='robotframework,debug,shell,repl',
-    install_requires=install_requires,
+    install_requires=[
+        'prompt-toolkit < 3',  # 3.0 is not compatible with py3.5
+        'robotframework >= 3.0',
+    ],
     tests_require=['pexpect', 'coverage'],
     test_suite='tests.test_debuglibrary.suite',
     platforms=['Linux', 'Unix', 'Windows', 'MacOS X'],
     classifiers=[
+        'Environment :: Console',
         'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
+        'Topic :: Utilities',
     ],
 )


### PR DESCRIPTION
* Re-use `read` to read `README.rst`
* Do `install_requires` in one go, merge it with its key
* Classifiers
  * Add:
    * `Environment :: Console`
    * `Programming Language :: Python :: 3 :: Only`
    * `Topic :: Utilities`
  * Re-order them lexicographically

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>