### PR TITLE
Force `prompt-toolkit >= 2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     url='https://github.com/xyb/robotframework-debuglibrary/',
     keywords='robotframework,debug,shell,repl',
     install_requires=[
-        'prompt-toolkit < 3',  # 3.0 is not compatible with py3.5
+        'prompt-toolkit >= 2, < 3',  # 3.0 is not compatible with py3.5
         'robotframework >= 3.0',
     ],
     tests_require=['pexpect', 'coverage'],


### PR DESCRIPTION
Since all the fuss in https://github.com/xyb/robotframework-debuglibrary/issues/36
was about "`prompt-toolkit` v1 being incompatible with v2",
we need to enforce it.

This commit partially reverts 92d01ac0dd1c9d2735ad60fdc39b15fe84d31231.

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>